### PR TITLE
fix(frontend): update test scripts to run in non-interactive mode

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,9 +8,9 @@
     "build": "tsc && vite build",
     "lint": "echo 'TypeScript files are checked by tsc, no JavaScript files to lint'",
     "preview": "vite preview",
-    "test": "vitest",
-    "test:ui": "vitest --ui",
-    "test:coverage": "vitest --coverage"
+    "test": "vitest --run",
+    "test:ui": "vitest --ui --run",
+    "test:coverage": "vitest --coverage --run"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Changes
- Added  flag to all test scripts in 
- Ensures tests don't hang in CI/CD environments
- Verified with local ACT run

## Testing
- [x] All frontend tests pass locally
- [x] Verified tests run in non-interactive mode with ACT
- [x] Confirmed test coverage is still generated

## Notes
This change makes the test scripts more reliable in CI/CD environments by preventing them from hanging in watch mode.